### PR TITLE
Allow pandas as optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ python:
     - 3.3
 sudo: false
 install:
-    - pip install . coveralls
+    - pip install -U pip
+    - pip install ".[test]" coveralls
 script:
     - nosetests --with-coverage --cover-package traittypes traittypes
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -78,11 +78,14 @@ setuptools_args = {}
 
 install_requires = setuptools_args['install_requires'] = [
     'traitlets>=4.2.2',
-    'numpy',
-    'pandas'
 ]
 
 extras_require = setuptools_args['extras_require'] = {
+    'test': [
+        'numpy',
+        'pandas',
+        'pytest',  # traitlets[test] require this
+    ]
 }
 
 if 'setuptools' in sys.modules:

--- a/traittypes/tests/test_import_errors.py
+++ b/traittypes/tests/test_import_errors.py
@@ -1,0 +1,10 @@
+
+import nose.tools as nt
+
+from ..traittypes import _DelayedImportError
+
+
+@nt.raises(RuntimeError)
+def test_delayed_access_raises():
+    dummy = _DelayedImportError('mypackage')
+    dummy.asarray([1, 2, 3])

--- a/traittypes/traittypes.py
+++ b/traittypes/traittypes.py
@@ -1,6 +1,21 @@
 from traitlets import TraitType, TraitError, Undefined
-import numpy as np
-import pandas as pd
+
+class _DelayedImportError(object):
+    def __init__(self, package_name):
+        self.package_name = package_name
+
+    def __getattribute__(self, name):
+        package_name = super(_DelayedImportError, self).__getattribute__('package_name')
+        raise RuntimeError('Missing dependency: %s' % package_name)
+
+try:
+    import numpy as np
+except ImportError:
+    np = _DelayedImportError('numpy')
+try:
+    import pandas as pd
+except ImportError:
+    pd = _DelayedImportError('pandas')
 
 
 class SciType(TraitType):
@@ -111,6 +126,7 @@ class DataFrame(SciType):
             obj._notify_trait(self.name, old_value, new_value)
 
     def __init__(self, default_value=Undefined, allow_none=False, dtype=None, **kwargs):
+        import pandas as pd
         self.dtype = dtype
         if default_value is Undefined:
             default_value = pd.DataFrame()
@@ -151,6 +167,7 @@ class Series(SciType):
             obj._notify_trait(self.name, old_value, new_value)
 
     def __init__(self, default_value=Undefined, allow_none=False, dtype=None, **kwargs):
+        import pandas as pd
         self.dtype = dtype
         if default_value is Undefined:
             default_value = pd.Series()


### PR DESCRIPTION
If someone just wants to support numpy arrays, there is no reason force a pandas dependency with this package. The numpy type could in principle also be guarded like this, to allow for a dependency on the "abstract" `SciType` trait?