### PR TITLE
Tweak validation code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
+    - 3.6
     - 3.5
-    - 3.4
     - 2.7
-    - 3.3
 sudo: false
 install:
     - pip install -U pip


### PR DESCRIPTION
Three main points:
- Refactor out SciType to be self contained (less of an abstract base class). Less repetition of code.
- Will not coerce `None` and `Undefined`.
- Gives a warning when coercing one ndarray to another (a copy is created).