### PR TITLE
Further tweak definitions

### DIFF
--- a/traittypes/tests/test_traittypes.py
+++ b/traittypes/tests/test_traittypes.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from unittest import TestCase
-from traitlets import HasTraits, TraitError, observe
+from traitlets import HasTraits, TraitError, observe, Undefined
 from traitlets.tests.test_traitlets import TraitTestBase
 from traittypes import Array, DataFrame, Series
 import numpy as np
@@ -56,11 +56,13 @@ class TestArray(TestCase):
             b = Array(dtype='int')
             c = Array(None, allow_none=True)
             d = Array([])
+            e = Array(Undefined)
         foo = Foo()
         self.assertTrue(np.array_equal(foo.a, np.array(0)))
         self.assertTrue(np.array_equal(foo.b, np.array(0)))
         self.assertTrue(foo.c is None)
         self.assertTrue(np.array_equal(foo.d, []))
+        self.assertTrue(foo.e is Undefined)
 
     def test_allow_none(self):
         class Foo(HasTraits):
@@ -116,19 +118,21 @@ class TestDataFrame(TestCase):
                 notifications.append(change)
         foo = Foo()
         foo.bar = [1, 2]
-        self.assertFalse(len(notifications))
+        self.assertEqual(notifications, [])
         foo.bar = [1, 1]
-        self.assertTrue(len(notifications))
+        self.assertEqual(len(notifications), 1)
 
     def test_initial_values(self):
         class Foo(HasTraits):
             a = DataFrame()
             b = DataFrame(None, allow_none=True)
             c = DataFrame([])
+            d = DataFrame(Undefined)
         foo = Foo()
         self.assertTrue(foo.a.equals(pd.DataFrame()))
         self.assertTrue(foo.b is None)
         self.assertTrue(foo.c.equals(pd.DataFrame([])))
+        self.assertTrue(foo.d is Undefined)
 
     def test_allow_none(self):
         class Foo(HasTraits):
@@ -142,7 +146,7 @@ class TestDataFrame(TestCase):
 
 class TestSeries(TestCase):
 
-    def test_sereis_equal(self):
+    def test_series_equal(self):
         notifications = []
         class Foo(HasTraits):
             bar = Series([1, 2])
@@ -151,19 +155,21 @@ class TestSeries(TestCase):
                 notifications.append(change)
         foo = Foo()
         foo.bar = [1, 2]
-        self.assertFalse(len(notifications))
+        self.assertEqual(notifications, [])
         foo.bar = [1, 1]
-        self.assertTrue(len(notifications))
+        self.assertEqual(len(notifications), 1)
 
     def test_initial_values(self):
         class Foo(HasTraits):
             a = Series()
             b = Series(None, allow_none=True)
             c = Series([])
+            d = Series(Undefined)
         foo = Foo()
         self.assertTrue(foo.a.equals(pd.Series()))
         self.assertTrue(foo.b is None)
         self.assertTrue(foo.c.equals(pd.Series([])))
+        self.assertTrue(foo.d is Undefined)
 
     def test_allow_none(self):
         class Foo(HasTraits):

--- a/traittypes/tests/test_validators.py
+++ b/traittypes/tests/test_validators.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import pytest
+
+from traitlets import HasTraits, TraitError
+
+from ..traittypes import SciType
+
+
+def test_coercion_validator():
+    # Test with a squeeze coercion
+    def truncate(trait, value):
+        return value[:10]
+
+    class Foo(HasTraits):
+        bar = SciType().valid(truncate)
+
+    foo = Foo(bar=list(range(20)))
+    assert foo.bar == list(range(10))
+    foo.bar = list(range(10, 40))
+    assert foo.bar == list(range(10, 20))
+
+
+def test_validaton_error():
+    # Test with a squeeze coercion
+    def maxlen(trait, value):
+        if len(value) > 10:
+            raise ValueError('Too long sequence!')
+        return value
+
+    class Foo(HasTraits):
+        bar = SciType().valid(maxlen)
+
+    # Check that it works as expected:
+    foo = Foo(bar=list(range(5)))
+    assert foo.bar == list(range(5))
+    # Check that it fails as expected:
+    with pytest.raises(TraitError):  # Should convert ValueError to TraitError
+        foo.bar = list(range(10, 40))
+    assert foo.bar == list(range(5))
+    # Check that it can again be set correctly
+    foo = Foo(bar=list(range(5, 10)))
+    assert foo.bar == list(range(5, 10))


### PR DESCRIPTION
Three main points:
- Adds some tests for code introduced in #22.
- Refactor the pandas types to have a common base (avoid repeating similar code).
- Allow `Undefined` as explicit default value by introducing a new sentinel value `Empty`. This new sentinel is used as the new default value for `default_value` (😅), such that backwards compatibility is retained. It signifies the behavior of initializing an empty data structure.