### PR TITLE
Fix numpy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ python:
 sudo: false
 install:
     - pip install -U pip
-    - pip install ".[test]" coveralls
+    - pip install -U --upgrade-strategy eager ".[test]" coveralls
+    - pip freeze
 script:
     - nosetests --with-coverage --cover-package traittypes traittypes
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,9 @@ install_requires = setuptools_args['install_requires'] = [
 
 extras_require = setuptools_args['extras_require'] = {
     'test': [
-        'numpy',
+        # TestIntArray.test_bad_values fails with numpy>=1.16.0
+        'numpy<1.16.0',
+
         'pandas',
         'xarray',
         'pytest',  # traitlets[test] require this


### PR DESCRIPTION
Hello,

`TestIntArray.test_bad_values` fails with `numpy>=1.16.0`, so it makes sense to pin `numpy` to `<1.16.0` for now.

These changes also:
 - Make CI update requirements
 - Add `pip freeze` command to CI `install` step