### PR TITLE
Fix TestIntArray.test_bad_values

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,7 @@ install_requires = setuptools_args['install_requires'] = [
 
 extras_require = setuptools_args['extras_require'] = {
     'test': [
-        # TestIntArray.test_bad_values fails with numpy>=1.16.0
-        'numpy<1.16.0',
-
+        'numpy',
         'pandas',
         'xarray',
         'pytest',  # traitlets[test] require this

--- a/traittypes/tests/test_traittypes.py
+++ b/traittypes/tests/test_traittypes.py
@@ -17,7 +17,7 @@ import xarray as xr
 
 
 class IntArrayTrait(HasTraits):
-    value = Array().tag(dtype=np.int)
+    value = Array(dtype=np.int).tag(dtype=np.int)
 
 
 class TestIntArray(TraitTestBase):


### PR DESCRIPTION
Hi there,

I'm not quite sure that it's a correct way to fix `test_bad_values`, but it works well with both `numpy~=1.15.0` and `nympy~=1.16.0`.