### PR TITLE
Remove _bad_values which is not validated and make traitlets fail

### DIFF
--- a/traittypes/tests/test_traittypes.py
+++ b/traittypes/tests/test_traittypes.py
@@ -27,7 +27,6 @@ class TestIntArray(TraitTestBase):
     obj = IntArrayTrait()
 
     _good_values = [1, [1, 2, 3], [[1, 2, 3], [4, 5, 6]], np.array([1])]
-    _bad_values = [[1, [0, 0]]]
 
     def assertEqual(self, v1, v2):
         return np.testing.assert_array_equal(v1, v2)


### PR DESCRIPTION
This make upstream test fail as _bad_value generate test that are
supposed to fail assignments.